### PR TITLE
feat: Add Ansible Automation for Lava Docker Node Service

### DIFF
--- a/impulse-automation/nodes/README.md
+++ b/impulse-automation/nodes/README.md
@@ -1,0 +1,129 @@
+# Node Service Deployment
+
+This repository includes Ansible playbooks and supporting files for deploying and managing the Node Service. The service uses Docker containers managed via Docker Compose to ensure easy and scalable deployments across multiple environments.
+
+## Prerequisites
+
+- **Ansible 2.9+**: Ensure Ansible is installed on your control machine.
+- **Docker**: Must be installed on the target hosts.
+- **Docker Compose**: Required for managing Dockerized applications.
+- **SSH Access**: Root or sudo access on the target hosts.
+
+## Repository Structure
+
+- **`group_vars`** and **`host_vars`**: Contains variables specific to hosts and groups. Customize these to fit the deployment context.
+- **`roles`**: Contains the tasks used for setting up the node.
+- **`templates`**: Jinja2 templates for generating Docker Compose and environment configuration files.
+- **`inventory`**: Hosts file defining the servers on which the node service will be deployed.
+
+## Installation and Setup
+
+### Clone the Repository
+
+Start by cloning this repository to your Ansible control machine:
+
+```bash
+git clone <repository-url>
+cd <repository-dir>
+```
+
+### Configure Inventory
+
+Edit the `inventory/hosts` file to add the IP addresses or hostnames of the machines where the service should be deployed.
+
+Example:
+
+```yaml
+all:
+  children:
+    lava_testnet_node_eu:
+      hosts:
+        192.168.1.100:
+          ansible_user: root
+          ansible_ssh_private_key_file: ~/.ssh/id_rsa
+```
+
+> You can declare certain parameters in the `ansible.cfg` configuration file or in `group_vars/all.yml`. These settings will be applied to all hosts at each startup
+
+ansible.cfg
+
+```ini
+[defaults]
+private_key_file = ~/.ssh/id_rsa
+```
+
+group_vars/all.yml
+
+```yml
+# group_vars/all.yml
+---
+ansible_user: root
+ansible_port: 22
+```
+
+### Set Role Variables
+
+Adjust role-specific variables in `group_vars/all.yml` and `host_vars/*.yml` to match your environment:
+
+## Deployment
+
+The deployment process involves setting directly configuring Docker networks, generating necessary configuration claims, and managing Docker containers through Docker Compose.
+
+### Prepare VM on clean system
+
+If you plan to deploy on a clean Debian or Ubuntu system without an installed Docker engine, use the `prepare` tag to install additional software:
+
+```bash
+ansible-playbook main.yml --tags prepare
+```
+
+![lava_node_prepare_gifsicle.gif](https://github.com/svetek/lava-ansible-deployment/blob/main/guides/lava_node_prepare_gifsicle.gif?raw=true)
+
+### Deploy the Service
+
+To deploy the Lava Node Service:
+
+```bash
+ansible-playbook main.yml --tags deploy
+```
+
+To download the snapshot, you need to run the following command:
+
+```bash
+ansible-playbook main.yml --tags snapshot
+```
+
+![lava_node_deploy_gifsicle.gif](https://github.com/svetek/lava-ansible-deployment/blob/main/guides/lava_node_deploy_gifsicle.gif?raw=true)
+
+## Managing
+
+Start the Service: Ensure the service is up and running:
+
+```bash
+ansible-playbook main.yml --tags start
+```
+
+Stop the Service: Safely stop the service when needed:
+
+```bash
+ansible-playbook main.yml --tags stop
+```
+
+Restart the Service: Restart the service to apply updates or changes:
+
+```bash
+ansible-playbook main.yml --tags restart
+```
+
+## Configuration Files
+
+- Docker Compose Configuration: Located at `{{ project_path }}/docker-compose.yml`, it defines the service setup, including image, ports, and environment variables.
+
+- Environment Variables: Stored in `{{ project_path }}/node.env`, this file includes environment-specific variables like log level and cache expiration.
+
+- Chain configuration and database: Stored in `{{ volume_path }}`.
+
+> Note:
+>
+> - That by default, the `ansible-playbook main.yml` command deploys and runs the service but does not download the snapshot.
+> - You can use serveral tags `ansible-playbook main.yml --tags "prepare,deploy,snapshot,start"` for fast deployment.

--- a/impulse-automation/nodes/ansible.cfg
+++ b/impulse-automation/nodes/ansible.cfg
@@ -1,0 +1,30 @@
+[defaults]
+# Defines the location of the inventory file that Ansible will use to find the host information.
+inventory = ./inventory/hosts
+
+# Path where Ansible will look for the roles.
+roles_path = roles
+
+# The number of parallel processes to use when Ansible executes tasks on multiple hosts.
+forks = 20
+
+# Disables SSH host key checking, making Ansible automatically accept unknown host keys.
+# This is useful in automated environments to avoid manual intervention.
+host_key_checking = False
+
+# Changes the default merging behavior of variables. With 'merge', hashes will be deeply merged.
+hash_behaviour = merge
+
+# Enables pipelining, which reduces the number of SSH operations required to execute a module.
+# This can result in a significant performance improvement but may not be compatible with all setups.
+pipelining = True
+
+# Specifies the SSH private key file to use for SSH authentication.
+private_key_file = ~/.ssh/svc_ansible
+
+[ssh_connection]
+# SSH arguments used when connecting to hosts.
+# - ForwardAgent=yes: Allows SSH agent forwarding.
+# - ControlMaster=auto: Enables the sharing of multiple sessions over a single network connection.
+# - ControlPersist=60s: Makes the master connection stay open in the background for up to 60 seconds after the initial connection, improving subsequent connection times.
+ssh_args = -o ForwardAgent=yes -o ControlMaster=auto -o ControlPersist=60s

--- a/impulse-automation/nodes/inventory/group_vars/all.yml
+++ b/impulse-automation/nodes/inventory/group_vars/all.yml
@@ -1,0 +1,9 @@
+# group_vars/all.yml
+---
+ansible_user: root
+ansible_port: 22
+project_type: node
+project_unique_name: "{{ project_name }}{% if network %}-{{ network }}{% endif %}-{{ project_type }}"
+service_path: /opt/services
+project_path: "{{ service_path }}/{{ project_unique_name }}"
+volume_path: "{{ container.volume_path }}"

--- a/impulse-automation/nodes/inventory/host_vars/lava_testnet_node_eu.yml
+++ b/impulse-automation/nodes/inventory/host_vars/lava_testnet_node_eu.yml
@@ -1,0 +1,55 @@
+# host_vars/lava_testnet_node_eu.yml
+---
+ansible_host: xxx.xxx.xxx.xxx                                         # IP address of the host
+project_name: lava
+environment_template: node.env.j2
+network: testnet
+
+# Container configuration
+container:
+  image: svetekllc/lava                                               # Docker image name
+  tag: v2.0.0-node                                                    # Docker image tag to specify version
+  limits:
+    cpu: 2                                                            # Maximum number of CPU cores the container can use
+    memory: 4gb                                                      # Maximum amount of memory the container can use
+  volume_path: /opt/{{ project_unique_name }}                         # Path where volumes are mounted in the host
+
+# Node-specific configuration
+node_config:
+  moniker: Lava                                                       # Custom name for the provider instance
+  chain_id: lava-testnet-2                                            # Blockchain network identifier
+  log_level: info                                                     # Logging level
+  config_path: /root/.lava                                            # Path to provider configuration files
+  database_backend: goleveldb                                         # AppDBBackend defines the database backend type to use for the application and snapshots DBs.
+  addrbook_url: ""
+  genesis_url: https://raw.githubusercontent.com/lavanet/lava-config/main/testnet-2/genesis_json/genesis.json
+  peers: ""
+  seeds: d1730b774b7c1d52dd9f6ae874a56de958aa147e@139.45.205.60:23656,51789af428293359348020d298143946c9a0492e@5.161.132.110:26656,802e15de52338029c6e2de2901c8cdd75f15ee9b@64.120.88.81:23656
+  state_sync: false
+  diff_height: 1000
+  public_rpc_url: https://public-rpc-testnet2.lavanet.xyz:443/rpc/    # Public URL for RPC connections
+
+# Network ports used by the node
+node_ports:
+  grpc: 9090                                                          # Port for gRPC service
+  api: 1317                                                           # Port for REST API service
+  p2p: 26656                                                          # Port for P2P service
+  rpc: 26657                                                          # Port for RPC service
+  metrics: 26660                                                      # Port for Prometheus Metrics
+
+networks:
+  - lava                                                              # Network label used for Docker networking
+
+# Wallet configuration
+wallet:
+  name: lava                                                          # Wallet name
+  password: ""                                                        # Wallet password. Required if the keyring_backend parameter is equal: os, file
+  keyring_backend: test                                               # Backend system for managing keys and secrets
+
+# Download Snapshot configuration
+download_tmp_dir: "{{ volume_path }}"
+download_files:
+  snapshot:
+    url: https://testnet-files.itrocket.net/lava/snap_lava.tar.lz4
+    file_ext: tar.lz4                                                  # File type zip / tar.lz4 / tar.zstd / none
+    unpack_dir: "{{ volume_path }}"

--- a/impulse-automation/nodes/inventory/hosts
+++ b/impulse-automation/nodes/inventory/hosts
@@ -1,0 +1,3 @@
+all:
+  hosts:
+    lava_testnet_node_eu:

--- a/impulse-automation/nodes/main.yml
+++ b/impulse-automation/nodes/main.yml
@@ -1,0 +1,39 @@
+---
+# The main playbook for nodes deployment
+- name: Deploying and managing the node Service
+  hosts: all
+  become: true
+  gather_facts: true
+  roles:
+    - role: prepare
+      tags:
+        - never
+        - prepare
+    - role: deploy
+      tags:
+        - deploy
+    - role: snapshot
+      tags:
+        - never
+        - snapshot
+  tasks:
+    - name: Run the service
+      community.docker.docker_compose_v2:
+        project_src: "{{ project_path }}"
+        state: present
+      tags:
+        - start
+    - name: Stop the service
+      community.docker.docker_compose_v2:
+        project_src: "{{ project_path }}"
+        state: stopped
+      tags:
+        - never
+        - stop
+    - name: Restart the service
+      community.docker.docker_compose_v2:
+        project_src: "{{ project_path }}"
+        state: restarted
+      tags:
+        - never
+        - restart

--- a/impulse-automation/nodes/roles/deploy/defaults/main.yml
+++ b/impulse-automation/nodes/roles/deploy/defaults/main.yml
@@ -1,0 +1,1 @@
+# roles/deploy/defaults/main.yml

--- a/impulse-automation/nodes/roles/deploy/tasks/main.yml
+++ b/impulse-automation/nodes/roles/deploy/tasks/main.yml
@@ -1,0 +1,56 @@
+# roles/deploy/tasks/main.yml
+---
+- name: Create a directory for the Docker Compose file
+  ansible.builtin.file:
+    path: "{{ project_path }}"
+    state: directory
+    mode: "0755"
+
+- name: Generate the Docker Compose file
+  ansible.builtin.template:
+    src: "docker-compose.yml.j2"
+    dest: "{{ project_path }}/docker-compose.yml"
+    mode: "0644"
+
+- name: Generate the node.env file
+  ansible.builtin.template:
+    src: "{{ environment_template }}"
+    dest: "{{ project_path }}/node.env"
+    mode: "0644"
+
+- name: Create the data volume directory
+  ansible.builtin.file:
+    path: "{{ volume_path }}"
+    state: directory
+    mode: "0755"
+
+- name: Get volume information
+  community.docker.docker_volume_info:
+    name: "{{ project_unique_name }}"
+  register: volume_info
+
+- name: Create the data volume
+  when:
+    - volume_info.exists
+    - volume_info.volume.Options.device != volume_path
+  block:
+    - name: Get container information
+      community.docker.docker_container_info:
+        name: "{{ project_unique_name }}"
+      register: container_info
+
+    - name: Remove the container
+      community.docker.docker_container:
+        name: "{{ project_unique_name }}"
+        state: absent
+      when: container_info.exists
+
+    - name: Remove the volume
+      community.docker.docker_volume:
+        name: "{{ project_unique_name }}"
+        state: absent
+      when: volume_info.exists
+
+- name: Create a network
+  community.docker.docker_network:
+    name: "{{ project_name }}"

--- a/impulse-automation/nodes/roles/deploy/templates/docker-compose.yml.j2
+++ b/impulse-automation/nodes/roles/deploy/templates/docker-compose.yml.j2
@@ -1,0 +1,48 @@
+---
+name: {{ project_unique_name }}
+
+services:
+  node:
+    image: {{ container.image }}:{{ container.tag }}
+    container_name: {{ project_unique_name }}
+    labels:
+      network: "{% if network %}{{ network }}{% else %}-no_network_set{% endif %}"
+    env_file:
+      - node.env
+    volumes:
+      - data:{{ node_config.config_path}}
+    ports:
+{% for key, value in node_ports.items() %}
+      - "{{ value }}:{{ value }}"
+{% endfor %}
+    networks:
+{% for value in networks %}
+      - {{ value }}
+{% endfor %}
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100m"
+        max-file: "1"
+    deploy:
+      resources:
+        limits:
+          cpus: "{{ container.limits.cpu }}"
+          memory: "{{ container.limits.memory }}"
+    restart: unless-stopped
+
+volumes:
+  data:
+    name: {{ project_unique_name }}
+    driver: local
+    driver_opts:
+      type: none
+      o: bind
+      device: {{ container.volume_path }}
+
+networks:
+{% for value in networks %}
+  {{ value }}:
+    name: {{ value }}
+    external: true
+{% endfor %}

--- a/impulse-automation/nodes/roles/deploy/templates/node.env.j2
+++ b/impulse-automation/nodes/roles/deploy/templates/node.env.j2
@@ -1,0 +1,75 @@
+### Node variables ###
+
+# The URL to download the address book.
+ADDRBOOK_URL="{{ node_config.addrbook_url }}"
+
+# The unique identifier for the blockchain network.
+CHAIN_ID="{{ node_config.chain_id }}"
+
+# The directory path where the node's configuration files are stored.
+CONFIG_PATH="{{ node_config.config_path }}"
+
+# The URL to download the genesis file of the network.
+GENESIS_URL="{{ node_config.genesis_url }}"
+
+### Enable state sync
+# Whether to enable state synchronization from other nodes. (true|false)
+STATE_SYNC="{{ node_config.state_sync | lower }}"
+# Blocks behind the highest height to start the state sync. (default: 1000)
+DIFF_HEIGHT="{{ node_config.diff_height }}"
+
+# AppDBBackend defines the database backend type to use for the application and snapshots DBs. (default: goleveldb)
+# Database backends: goleveldb | cleveldb | boltdb | rocksdb | badgerdb
+DB_BACKEND="{{ node_config.database_backend }}"
+
+### Set the wallet name and password.
+# The local name for the user's wallet.
+WALLET="{{ wallet.name }}"
+# The password for the wallet, must be at least 8 characters.
+WALLET_PASS="{{ wallet.password }}"
+# The storage mechanism for keys. (default: os)
+KEYRING_BACKEND="{{ wallet.keyring_backend }}"
+
+### Set the logging level.
+# The verbosity of logs output [trace|debug|info|warn|error|fatal|panic] (default: info)
+LOGLEVEL="{{ node_config.log_level }}"
+
+### Moniker name
+# The custom name to identify your node in the network.
+MONIKER="{{ node_config.moniker | default('node') }}"
+
+### Set the peers or seeds.
+# Direct connections for network communication.
+PEERS="{{ node_config.peers }}"
+# Known nodes to help discover other peers in the network.
+SEEDS="{{ node_config.seeds }}"
+
+### Metrics and node communication ports.
+{% if node_ports.grpc is defined %}
+# GRPC port for node communication. (default: 9090)
+NODE_GRPC_PORT="{{ node_ports.grpc }}"
+{% endif %}
+{% if node_ports.jrpc is defined %}
+# JSON-RPC port for node communication (default: 8545)
+NODE_JRPC_PORT="{{ node_ports.jrpc }}"
+{% endif %}
+{% if node_ports.api is defined %}
+# API port for node communication. (default: 1317)
+NODE_API_PORT="{{ node_ports.api }}"
+{% endif %}
+{% if node_ports.p2p is defined %}
+# The port for peer-to-peer network communication. (default: 26656)
+NODE_P2P_PORT="{{ node_ports.p2p }}"
+{% endif %}
+{% if node_ports.rpc is defined %}
+# The port for RPC server. (default: 26657)
+NODE_RPC_PORT="{{ node_ports.rpc }}"
+{% endif %}
+{% if node_ports.metrics is defined %}
+# The port for Prometheus metrics. (default: 26660)
+METRICS_PORT="{{ node_ports.metrics }}"
+{% endif %}
+
+### Public RPC URL
+# The URL to access the public RPC server for the network.
+PUBLIC_RPC="{{ node_config.public_rpc_url }}"

--- a/impulse-automation/nodes/roles/deploy/vars/main.yml
+++ b/impulse-automation/nodes/roles/deploy/vars/main.yml
@@ -1,0 +1,7 @@
+# roles/deploy/vars/main.yml
+
+# In Ansible, the priority of variable values is determined by 
+# the order in which they are defined, known as variable precedence.
+# Variables defined in roles/deploy/vars/main.yml can override the values set in the inventory
+# if they are specified later in the precedence order.
+

--- a/impulse-automation/nodes/roles/prepare/meta/main.yml
+++ b/impulse-automation/nodes/roles/prepare/meta/main.yml
@@ -1,0 +1,21 @@
+# roles/prepare/meta/main.yml
+---
+dependencies: []
+galaxy_info:
+  author: Michael
+  description: The role for deploying the lava node service
+  company: Impulse Expert | https://impulse.expert
+  license: GPL
+  min_ansible_version: "2.9"
+  platforms:
+    - name: Ubuntu
+      versions:
+        - xenial
+        - bionic
+        - focal
+    - name: Debian
+      versions:
+        - buster
+        - bullseye
+        - bookworm
+

--- a/impulse-automation/nodes/roles/prepare/tasks/main.yml
+++ b/impulse-automation/nodes/roles/prepare/tasks/main.yml
@@ -1,0 +1,64 @@
+# roles/prepare/tasks/main.yml
+---
+- name: Update the apt cache
+  ansible.builtin.apt:
+    update_cache: true
+    cache_valid_time: 3600
+
+# Turn off: need other role process for update runtime systems
+#- name: Upgrade all apt packages
+#  ansible.builtin.apt:
+#    upgrade: dist
+
+- name: Install necessary packages
+  ansible.builtin.apt:
+    name:
+      - software-properties-common
+      - apt-transport-https
+      - ca-certificates
+      - sudo
+      - aria2
+      - curl
+      - htop
+      - wget
+      - jq
+      - lz4
+      - rsync
+    state: present
+
+- name: Add Docker Repository for Debian
+  when: ansible_facts['distribution'] == "Debian"
+  ansible.builtin.shell: |
+    install -m 0755 -d /etc/apt/keyrings
+    curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+    chmod a+r /etc/apt/keyrings/docker.asc
+
+    # Add the repository to Apt sources:
+    echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
+    $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+    sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+- name: Add Docker Repository for Ubuntu
+  when: ansible_facts['distribution'] == "Ubuntu"
+  ansible.builtin.shell: |
+    install -m 0755 -d /etc/apt/keyrings
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+    chmod a+r /etc/apt/keyrings/docker.asc
+
+    # Add the repository to Apt sources:
+    echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+    $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+    sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+- name: Update apt and install docker-ce
+  ansible.builtin.apt:
+    name:
+      - docker-ce
+      - docker-ce-cli
+      - containerd.io
+      - docker-buildx-plugin
+      - docker-compose-plugin
+    state: present
+    update_cache: true

--- a/impulse-automation/nodes/roles/prepare/vars/main.yml
+++ b/impulse-automation/nodes/roles/prepare/vars/main.yml
@@ -1,0 +1,7 @@
+# roles/prepare/vars/main.yml
+
+# In Ansible, the priority of variable values is determined by 
+# the order in which they are defined, known as variable precedence.
+# Variables defined in roles/deploy/vars/main.yml can override the values set in the inventory
+# if they are specified later in the precedence order.
+

--- a/impulse-automation/nodes/roles/snapshot/defaults/main.yml
+++ b/impulse-automation/nodes/roles/snapshot/defaults/main.yml
@@ -1,0 +1,1 @@
+# roles/snapshot/defaults/main.yml

--- a/impulse-automation/nodes/roles/snapshot/handlers/main.yml
+++ b/impulse-automation/nodes/roles/snapshot/handlers/main.yml
@@ -1,0 +1,2 @@
+# roles/snapshot/handlers/main.yml
+

--- a/impulse-automation/nodes/roles/snapshot/meta/main.yml
+++ b/impulse-automation/nodes/roles/snapshot/meta/main.yml
@@ -1,0 +1,21 @@
+# roles/snapshot/meta/main.yml
+---
+dependencies: []
+galaxy_info:
+  author: Michael
+  description: The role for managing the snapshot
+  company: Impulse Expert | https://impulse.expert
+  license: GPL
+  min_ansible_version: "2.9"
+  platforms:
+    - name: Ubuntu
+      versions:
+        - xenial
+        - bionic
+        - focal
+    - name: Debian
+      versions:
+        - buster
+        - bullseye
+        - bookworm
+

--- a/impulse-automation/nodes/roles/snapshot/tasks/main.yml
+++ b/impulse-automation/nodes/roles/snapshot/tasks/main.yml
@@ -1,0 +1,49 @@
+# roles/snapshot/tasks/main.yml
+---
+- name: Create unpack directory
+  ansible.builtin.file:
+    path: "{{ item.value.unpack_dir }}"
+    state: directory
+    mode: '0755'
+  loop: "{{ download_files | dict2items }}"
+  loop_control:
+    label: "{{ item.key }} & directory={{ item.value.unpack_dir }}"
+
+- name: Download files to tmp folder use aria2c
+  ansible.builtin.shell: aria2c -x6 --auto-file-renaming=false --continue=true {{ item.value.url }} --dir={{ download_tmp_dir }} --out={{ item.key }}.{{ item.value.file_ext }} 2>&1 >{{ download_tmp_dir }}/{{ item.key }}.{{ item.value.file_ext }}.output
+  async: 21600    # Maximum allowed time in Seconds
+  poll: 10        # Polling Interval in Seconds
+  loop: "{{ download_files | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}.{{ item.value.file_ext }}"
+
+- name: Extract tar.gz
+  ansible.builtin.shell: "tar -xzf {{ download_tmp_dir }}/{{ item.key }}.{{ item.value.file_ext }} -C {{ item.value.unpack_dir }}"
+  loop: "{{ download_files | dict2items }}"
+  when: item.value.file_ext == "tar.gz"
+
+- name: Extract tar.lz4
+  ansible.builtin.shell: "lz4 -c -d {{ download_tmp_dir }}/{{ item.key }}.{{ item.value.file_ext }} | tar -x -C {{ item.value.unpack_dir }}"
+  loop: "{{ download_files | dict2items }}"
+  when: item.value.file_ext == "tar.lz4"
+
+- name: Extract zip
+  ansible.builtin.shell: "unzip -o {{ download_tmp_dir }}/{{ item.key }}.{{ item.value.file_ext }} -d {{ item.value.unpack_dir }}"
+  loop: "{{ download_files | dict2items }}"
+  when: item.value.file_ext == "zip"
+
+- name: Extract tar.zstd
+  ansible.builtin.shell: "zstd -cd {{ download_tmp_dir }}/{{ item.key }}.{{ item.value.file_ext }} | tar -x -C {{ item.value.unpack_dir }}"
+  loop: "{{ download_files | dict2items }}"
+  when: item.value.file_ext == "tar.zstd"
+
+- name: none
+  ansible.builtin.shell: "pwd"
+  loop: "{{ download_files | dict2items }}"
+  when: item.value.file_ext == "none"
+
+- name: Remove snapshot file (delete file)
+  ansible.builtin.file:
+    path: "{{ download_tmp_dir }}/{{ item.key }}.{{ item.value.file_ext }}"
+    state: absent
+  loop: "{{ download_files | dict2items }}"

--- a/impulse-automation/nodes/roles/snapshot/vars/main.yml
+++ b/impulse-automation/nodes/roles/snapshot/vars/main.yml
@@ -1,0 +1,6 @@
+# roles/snapshot/vars/main.yml
+
+# In Ansible, the priority of variable values is determined by 
+# the order in which they are defined, known as variable precedence.
+# Variables defined in roles/deploy/vars/main.yml can override the values set in the inventory
+# if they are specified later in the precedence order.


### PR DESCRIPTION
Ansible Automation for Lava Docker Node Service from https://github.com/lavanet/ansible/pull/1

This repository contains Ansible playbooks and templates essential for setting up various Lava Services using Docker and Docker Compose. These tools ensure easy, scalable deployments across multiple environments adaptive to specific service requirements of the Lava ecosystem.

Directory Structure
/node: Dedicated to setting up and managing Lava nodes with a focus on ensuring optimal performance and reliability.

It's equipped with its own README.md providing detailed documentation on the deployment and management processes for the respective service. Explore this directory to understand specific configurations and operational procedures related to node service.